### PR TITLE
style(header): adjust padding and margin on mobile header layout

### DIFF
--- a/src/components/organisms/header/Header.tsx
+++ b/src/components/organisms/header/Header.tsx
@@ -23,9 +23,9 @@ export function Header() {
       </div>
       {/* Tablet & Mobile only: show logo and menu */}
       <div className="flex lg:hidden h-full w-full bg-yellow-500">
-        <div className="w-full flex relative bg-green-500">
+        <div className="w-full flex relative bg-green-500 p-0">
           <MobileMenu />
-          <div className="items-center justify-center flex bg-red-500">
+          <div className="items-center justify-center flex bg-red-500 mr-[-5px]">
             <a href="/" className="logo-button">
               <img
                 src="/assets/img/logo-angie.png"


### PR DESCRIPTION
Refines the mobile header container by explicitly setting padding to zero and applies a slight negative right margin to the logo wrapper. These tweaks improve alignment and spacing for tablet and mobile views, enhancing visual consistency.